### PR TITLE
Add support for record types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,6 @@ webpack.config.js
 
 #OutputDir
 /Publish
+
+# IntelliJ-based IDE configuration (ie. Rider)
+/.idea

--- a/JsonClassGeneratorLib/CodeWriters/CSharpCodeWriter.cs
+++ b/JsonClassGeneratorLib/CodeWriters/CSharpCodeWriter.cs
@@ -337,7 +337,7 @@ namespace Xamasoft.JsonClassGenerator.CodeWriters
                 // this is required because every line except the last should end with a comma
                 if (config.RecordTypes && !first)
                 {
-                    sw.Append($",{Environment.NewLine}");
+                    sw.AppendLine(",");
                 }
 
                 if( !first && ( ( propertyAttribute.Length > 0 && !config.RecordTypes ) || config.ExamplesInDocumentation) )

--- a/JsonClassGeneratorLib/CodeWriters/CSharpCodeWriter.cs
+++ b/JsonClassGeneratorLib/CodeWriters/CSharpCodeWriter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace Xamasoft.JsonClassGenerator.CodeWriters
@@ -217,8 +216,15 @@ namespace Xamasoft.JsonClassGenerator.CodeWriters
             const string visibility = "public";
 
             var className = type.AssignedName;
-            sw.AppendFormat(indentTypes + "{0} class {1}{2}", visibility, className, Environment.NewLine);
-            sw.AppendLine  (indentTypes + "{");
+            if (config.RecordTypes)
+            {
+                sw.AppendFormat(indentTypes + "{0} record {1}({2}", visibility, className, Environment.NewLine);
+            }
+            else
+            {
+                sw.AppendFormat(indentTypes + "{0} class {1}{2}", visibility, className, Environment.NewLine);
+                sw.AppendLine  (indentTypes + "{");
+            }
 
 #if CAN_SUPRESS
             var shouldSuppressWarning = config.InternalVisibility && !config.UseProperties && !config.ExplicitDeserialization;
@@ -251,7 +257,11 @@ namespace Xamasoft.JsonClassGenerator.CodeWriters
             }
 #endif
 
-            if ((!config.UseNestedClasses) || (config.UseNestedClasses && !type.IsRoot))
+            if (config.RecordTypes)
+            {
+                sw.AppendLine(indentTypes + ");");
+            }
+            else if ((!config.UseNestedClasses) || (config.UseNestedClasses && !type.IsRoot))
             {
                 sw.AppendLine(indentTypes + "}");
             }
@@ -323,9 +333,17 @@ namespace Xamasoft.JsonClassGenerator.CodeWriters
                 string classPropertyName = this.GetCSharpPascalCaseName(field.MemberName);
                 string propertyAttribute = config.GetCSharpJsonAttributeCode(field);
 
-                if( !first && (propertyAttribute.Length > 0 || config.ExamplesInDocumentation) )
+                // If we are using record types and this is not the first iteration, add a comma and newline to the previous line
+                // this is required because every line except the last should end with a comma
+                if (config.RecordTypes && !first)
+                {
+                    sw.Append($",{Environment.NewLine}");
+                }
+
+                if( !first && ( ( propertyAttribute.Length > 0 && !config.RecordTypes ) || config.ExamplesInDocumentation) )
                 {
                     // If rendering examples/XML comments - or property attributes - then add a newline before the property for readability's sake (except if it's the first property in the class)
+                    // For record types, we want all members to be next to each other, unless when using examples
                     sw.AppendLine();
                 }
 
@@ -340,10 +358,26 @@ namespace Xamasoft.JsonClassGenerator.CodeWriters
                 if (propertyAttribute.Length > 0)
                 {
                     sw.Append(indentMembers);
-                    sw.AppendLine(propertyAttribute);
+                    sw.Append(propertyAttribute);
+
+                    if (!config.RecordTypes)
+                        sw.AppendLine();
                 }
 
-                if (config.UseFields)
+                // record types is not compatible with UseFields, so it comes first
+                if (config.RecordTypes)
+                {
+                    // NOTE: not adding newlines here, that happens at the start of the loop. We need this so we can lazily add commas at the end.
+                    if(field.Type.Type == JsonTypeEnum.Array)
+                    {
+                        sw.AppendFormat(" IReadOnlyList<{0}> {1}", this.GetTypeName(field.Type.InternalType, config), classPropertyName);
+                    }
+                    else
+                    {
+                        sw.AppendFormat(" {0} {1}", field.Type.GetTypeName(), classPropertyName);
+                    }
+                }
+                else if (config.UseFields)
                 {
                     sw.AppendFormat(indentMembers + "public {0}{1} {2};{3}", config.ImmutableClasses ? "readonly " : "", field.Type.GetTypeName(), classPropertyName, Environment.NewLine);
                 }
@@ -369,6 +403,10 @@ namespace Xamasoft.JsonClassGenerator.CodeWriters
 
                 first = false;
             }
+
+            // emit a final newline if we're dealing with record types
+            if (config.RecordTypes)
+                sw.AppendLine();
 
         }
 

--- a/JsonClassGeneratorLib/IJsonClassGeneratorConfig.cs
+++ b/JsonClassGeneratorLib/IJsonClassGeneratorConfig.cs
@@ -29,6 +29,7 @@ namespace Xamasoft.JsonClassGenerator
         bool         UseNamespaces              { get; }
         bool         ExamplesInDocumentation    { get; set; }
         bool         ImmutableClasses           { get; set; }
+        bool         RecordTypes                { get; set; }
         bool         NoSettersForCollections    { get; set; }
 
         bool ArrayAsList();
@@ -50,14 +51,15 @@ namespace Xamasoft.JsonClassGenerator
             
 
             string name = field.JsonMemberName;
+            string attributeTarget = config.RecordTypes ? "property:" : string.Empty;
 
             if (config.UseJsonPropertyName)
             {
-                return "[JsonPropertyName(\"" + name + "\")]";
+                return $"[{attributeTarget}JsonPropertyName(\"{name}\")]";
             }
             else if (config.UseJsonAttributes || field.ContainsSpecialChars)
             {
-                return "[JsonProperty(\"" + name + "\")]";
+                return $"[{attributeTarget}JsonProperty(\"{name}\")]";
             }
             else
             {

--- a/JsonClassGeneratorLib/JsonClassGenerator.cs
+++ b/JsonClassGeneratorLib/JsonClassGenerator.cs
@@ -7,10 +7,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
 using Xamasoft.JsonClassGenerator.CodeWriters;
 
 namespace Xamasoft.JsonClassGenerator
@@ -39,6 +37,7 @@ namespace Xamasoft.JsonClassGenerator
         public bool         UseNamespaces              => !String.IsNullOrEmpty(this.Namespace);
         public bool         ExamplesInDocumentation    { get; set; }
         public bool         ImmutableClasses           { get; set; }
+        public bool         RecordTypes                { get; set; }
         public bool         NoSettersForCollections    { get; set; }
 
         #endregion

--- a/TESTS-JSON-to-CSHARP/TESTS-JSON-to-CSHARP.csproj
+++ b/TESTS-JSON-to-CSHARP/TESTS-JSON-to-CSHARP.csproj
@@ -92,6 +92,8 @@
     <Content Include="Test_11_NoListSetter_OUTPUT1.txt" />
     <Content Include="Test_17_RECORD_TYPES_INPUT.txt" />
     <Content Include="Test_17_RECORD_TYPES_OUTPUT.txt" />
+    <Content Include="Test_17_RECORD_TYPES_OUTPUT_NEWTONSOFT.txt" />
+    <Content Include="Test_17_RECORD_TYPES_OUTPUT_SYSTEMTEXTJSON.txt" />
     <Content Include="Test_5_BASIC_SCENARIO_INPUT.txt" />
     <Content Include="Test_5_BASIC_SCENARIO_OUTPUT.txt" />
     <Content Include="Test_1_2_SETTINGS_PASCAL_INPUT.txt" />

--- a/TESTS-JSON-to-CSHARP/TESTS-JSON-to-CSHARP.csproj
+++ b/TESTS-JSON-to-CSHARP/TESTS-JSON-to-CSHARP.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Test_0_DIAGNOSTICS.cs" />
     <Compile Include="Test_11_NoListSetter.cs" />
+    <Compile Include="Test_17_RECORD_TYPES.cs" />
     <Compile Include="Test_5_BASIC_SCENARIO.cs" />
     <Compile Include="Test_1_2_SETTINGS_PASCAL.cs" />
     <Compile Include="Test_1_3_SETTINGS_FIELDS.cs" />
@@ -89,6 +90,8 @@
     <Content Include="Test_11_NoListSetter_INPUT1.txt" />
     <Content Include="Test_11_NoListSetter_OUTPUT.txt" />
     <Content Include="Test_11_NoListSetter_OUTPUT1.txt" />
+    <Content Include="Test_17_RECORD_TYPES_INPUT.txt" />
+    <Content Include="Test_17_RECORD_TYPES_OUTPUT.txt" />
     <Content Include="Test_5_BASIC_SCENARIO_INPUT.txt" />
     <Content Include="Test_5_BASIC_SCENARIO_OUTPUT.txt" />
     <Content Include="Test_1_2_SETTINGS_PASCAL_INPUT.txt" />

--- a/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES.cs
+++ b/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES.cs
@@ -25,6 +25,7 @@ namespace TESTS_JSON_TO_CSHARP
             };
 
             string actual = jsonClassGenerator.GenerateClasses(input, out _).ToString();
+            // Console.WriteLine("Actual:\n" + actual);
 
             var outputFixed = output.Replace(Environment.NewLine, "").Replace(" ", "").Replace("\t", "");
             var actualFixed = actual.Replace(Environment.NewLine, "").Replace(" ", "").Replace("\t", "");

--- a/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES.cs
+++ b/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES.cs
@@ -12,8 +12,25 @@ namespace TESTS_JSON_TO_CSHARP
         [TestMethod]
         public void Run()
         {
+            DoTest(null);
+        }
+
+        [TestMethod]
+        public void RunNewtonsoft()
+        {
+            DoTest(false, "_NEWTONSOFT");
+        }
+
+        [TestMethod]
+        public void RunSystemTextJson()
+        {
+            DoTest(true, "_SYSTEMTEXTJSON");
+        }
+
+        private static void DoTest(bool? useSystemTextJson, string outputFileSuffix = "")
+        {
             string inputPath = Directory.GetCurrentDirectory().Replace("bin\\Debug", "") + @"Test_17_RECORD_TYPES_INPUT.txt";
-            string outputPath = Directory.GetCurrentDirectory().Replace("bin\\Debug", "") + @"Test_17_RECORD_TYPES_OUTPUT.txt";
+            string outputPath = Directory.GetCurrentDirectory().Replace("bin\\Debug", "") + $@"Test_17_RECORD_TYPES_OUTPUT{outputFileSuffix}.txt";
             string input = File.ReadAllText(inputPath);
             string output = File.ReadAllText(outputPath);
 
@@ -21,7 +38,8 @@ namespace TESTS_JSON_TO_CSHARP
             {
                 CodeWriter = new CSharpCodeWriter(),
                 RecordTypes = true,
-                UseJsonPropertyName = true, // TODO: also test with newtonsoft json
+                UseJsonPropertyName = useSystemTextJson == true,
+                UseJsonAttributes = useSystemTextJson == false,
             };
 
             string actual = jsonClassGenerator.GenerateClasses(input, out _).ToString();

--- a/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES.cs
+++ b/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xamasoft.JsonClassGenerator;
+using Xamasoft.JsonClassGenerator.CodeWriters;
+
+namespace TESTS_JSON_TO_CSHARP
+{
+    [TestClass]
+    public class Test_17_RECORD_TYPES
+    {
+        [TestMethod]
+        public void Run()
+        {
+            string inputPath = Directory.GetCurrentDirectory().Replace("bin\\Debug", "") + @"Test_17_RECORD_TYPES_INPUT.txt";
+            string outputPath = Directory.GetCurrentDirectory().Replace("bin\\Debug", "") + @"Test_17_RECORD_TYPES_OUTPUT.txt";
+            string input = File.ReadAllText(inputPath);
+            string output = File.ReadAllText(outputPath);
+
+            JsonClassGenerator jsonClassGenerator = new JsonClassGenerator
+            {
+                CodeWriter = new CSharpCodeWriter(),
+                RecordTypes = true,
+                UseJsonPropertyName = true, // TODO: also test with newtonsoft json
+            };
+
+            string actual = jsonClassGenerator.GenerateClasses(input, out _).ToString();
+
+            var outputFixed = output.Replace(Environment.NewLine, "").Replace(" ", "").Replace("\t", "");
+            var actualFixed = actual.Replace(Environment.NewLine, "").Replace(" ", "").Replace("\t", "");
+
+            Assert.AreEqual(outputFixed, actualFixed);
+        }
+    }
+}

--- a/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_INPUT.txt
+++ b/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_INPUT.txt
@@ -1,0 +1,13 @@
+{
+	"key": "my_key",
+	"values": [
+		{
+			"id": 123,
+			"real": true,
+		},
+		{
+			"id": 456,
+			"real": false
+		}
+	]
+}

--- a/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_OUTPUT.txt
+++ b/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_OUTPUT.txt
@@ -1,10 +1,10 @@
 // Root myDeserializedClass = JsonSerializer.Deserialize<Root>(myJsonResponse);
-public record Values(
+public record Value(
     [property: JsonPropertyName("id")] int Id,
-    [property: JsonPropertyName("real")] bool Real,
+    [property: JsonPropertyName("real")] bool Real
 );
 
 public record Root(
-    [property: JsonPropertyName("id")] string Key,
-    [property: JsonPropertyName("values")] Values[] Values
+    [property: JsonPropertyName("key")] string Key,
+    [property: JsonPropertyName("values")] IReadOnlyList<Value> Values
 );

--- a/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_OUTPUT.txt
+++ b/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_OUTPUT.txt
@@ -1,0 +1,10 @@
+// Root myDeserializedClass = JsonSerializer.Deserialize<Root>(myJsonResponse);
+public record Values(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("real")] bool Real,
+);
+
+public record Root(
+    [property: JsonPropertyName("id")] string Key,
+    [property: JsonPropertyName("values")] Values[] Values
+);

--- a/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_OUTPUT.txt
+++ b/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_OUTPUT.txt
@@ -1,10 +1,10 @@
-// Root myDeserializedClass = JsonSerializer.Deserialize<Root>(myJsonResponse);
+// Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
 public record Value(
-    [property: JsonPropertyName("id")] int Id,
-    [property: JsonPropertyName("real")] bool Real
+    int id,
+    bool real
 );
 
 public record Root(
-    [property: JsonPropertyName("key")] string Key,
-    [property: JsonPropertyName("values")] IReadOnlyList<Value> Values
+    string key,
+    IReadOnlyList<Value> values
 );

--- a/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_OUTPUT_NEWTONSOFT.txt
+++ b/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_OUTPUT_NEWTONSOFT.txt
@@ -1,0 +1,10 @@
+// Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
+public record Value(
+    [property: JsonProperty("id")] int Id,
+    [property: JsonProperty("real")] bool Real
+);
+
+public record Root(
+    [property: JsonProperty("key")] string Key,
+    [property: JsonProperty("values")] IReadOnlyList<Value> Values
+);

--- a/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_OUTPUT_SYSTEMTEXTJSON.txt
+++ b/TESTS-JSON-to-CSHARP/Test_17_RECORD_TYPES_OUTPUT_SYSTEMTEXTJSON.txt
@@ -1,0 +1,10 @@
+// Root myDeserializedClass = JsonSerializer.Deserialize<Root>(myJsonResponse);
+public record Value(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("real")] bool Real
+);
+
+public record Root(
+    [property: JsonPropertyName("key")] string Key,
+    [property: JsonPropertyName("values")] IReadOnlyList<Value> Values
+);


### PR DESCRIPTION
This PR adds support for generating record type models.

I have not edited the WinForms project as it's been a very long time since I worked with it, and I use the web interface anyway. I couldn't add the toggle there since it doesn't seem to be in this repo.

Closes #62.
