### PR TITLE
Add fields length check before subtraction

### DIFF
--- a/JsonClassGeneratorLib/CodeWriters/PythonCodeWriter.cs
+++ b/JsonClassGeneratorLib/CodeWriters/PythonCodeWriter.cs
@@ -147,11 +147,13 @@ namespace Xamasoft.JsonClassGenerator.CodeWriters
                 mappingFunction.AppendLine(mappingString);
                 fields.Append(internalPropertyAttribute + ", ");
             }
-            
-            // Remove trailing comma
-            fields.Length--;
-            fields.Length--;
-            
+
+            // Remove trailing comma and trailing space
+            if (fields.Length > 0)
+            {
+                fields.Length -= 2;
+            }
+
             // Write Dictionnary Mapping Functions
             sw.AppendLine();
             sw.AppendLine("    @staticmethod");


### PR DESCRIPTION
Fix #112 

There are situations where the **fields** SB is empty, let's check for that.

For reference, I believe the same was done in [DartCodeWriter.cs](https://github.com/hilalhakla/Json2CSharpCodeGenerator/blob/75878316ec7748625c11b03eed7f978e524a1128/JsonClassGeneratorLib/CodeWriters/DartCodeWriter.cs#L141)